### PR TITLE
vignette for stock areas

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,9 +26,11 @@ Remotes:
   NOAA-EDAB/mscatch,
   NOAA-EDAB/survdat,
   NOAA-EDAB/ecodata,
-  r4atlantis/atlantisom
+  r4atlantis/atlantisom,
+  NEFSC/NEFSCspatial
 VignetteBuilder: knitr
 Suggests:
+  NEFSCspatial,
   ecodata,
   DT,
   kableExtra,

--- a/data-raw/R/create_species_rules_table.R
+++ b/data-raw/R/create_species_rules_table.R
@@ -1,0 +1,111 @@
+#' Creates table for GBLandingsLength.rmd
+#' 
+#' reads in the output get_species_object_mskeyrun and forms a table to display
+#' the inputs used to expand the landings to length and form the age-length key
+#' 
+#' @param nm Character string. Name of field in `get_species_object_mskeyrun` output. Either "gearcodes" or "marketCodes"
+#' @param reuse Character string. Name of field to relabel the "use" column
+#' @param recombine Character string. Name of field to relabel the "combine" column
+#' 
+#' @return flextable object
+
+library(magrittr)
+
+
+create_species_rules_table1 <- function(nm,reuse,recombine) {
+  
+  itis <- mskeyrun::focalSpecies %>%
+    dplyr::distinct(SPECIES_ITIS) %>%
+    dplyr::filter(!(SPECIES_ITIS %in% c(164727))) %>%
+    dplyr::pull()
+  
+  maindf <- data.frame()
+  
+  for (iitis in 1:length(itis)) {
+    spitis <- itis[iitis]
+    speciesRules <- mscatch::get_species_object_mskeyrun(spitis)
+
+    zz <- speciesRules[[nm]]
+    zz$species <- speciesRules$speciesName
+    
+    zz <- zz %>% 
+      dplyr::rename(!!reuse := use,
+                    !!recombine := combine) %>%
+      dplyr::select(species,!!reuse,!!recombine) 
+    
+    maindf <- rbind(maindf,zz)
+
+
+  }
+  
+  tab <- maindf  %>%
+    dplyr::group_by(species,.data[[reuse]]) %>%
+    dplyr::summarize(temp=paste(sort(.data[[recombine]]),collapse = ","),.groups = "drop") %>% 
+    dplyr::rename(!!recombine := temp) %>%
+    flextable::flextable() %>%
+    flextable::merge_v(j="species") %>%
+    flextable::theme_vanilla()
+
+
+  return(tab)
+}
+
+
+#' Creates table for GBLandingsLength.rmd
+#' 
+#' reads in the output get_species_object_mskeyrun and forms a table to display
+#' the inputs used to expand the landings to length and form the age-length key
+#' 
+#' @return flextable object
+
+create_species_rules_table2 <- function() {
+  
+  itis <- mskeyrun::focalSpecies %>%
+    dplyr::distinct(SPECIES_ITIS) %>%
+    dplyr::filter(!(SPECIES_ITIS %in% c(164727))) %>%
+    dplyr::pull()
+  
+  maindf <- data.frame()
+  
+  for (iitis in 1:length(itis)) {
+    spitis <- itis[iitis]
+
+    speciesRules <- mscatch::get_species_object_mskeyrun(spitis)
+    
+    speciesRules$gearCodes <- NULL
+    speciesRules$marketCodes <- NULL
+    
+    for (ifi in names(speciesRules)) {
+
+      if (length(speciesRules[[ifi]]) > 1) {
+        speciesRules[ifi] <- paste(speciesRules[[ifi]], collapse = ",")
+      } 
+    
+    }
+    zz <- as.data.frame(speciesRules)
+    
+    maindf <- rbind(maindf,zz)
+
+  }
+  
+  stockAreaEqual <- maindf %>% 
+    dplyr::select(statStockArea) %>% 
+    dplyr::distinct() %>% 
+    nrow() 
+  
+  if (stockAreaEqual == 1) {
+    message(paste0("All species catch data are pulled from the statistical areas, ",speciesRules$statStockArea))
+  }
+
+  tab <- maindf  %>%
+    dplyr::rename(species = speciesName) %>% 
+    dplyr::select(-c(species_itis,SVSPP,statStockArea)) %>%
+    flextable::flextable() %>%
+    flextable::merge_v(j="species") %>%
+    flextable::theme_vanilla()
+  # 
+  # 
+  return(tab)
+  #return(maindf)
+}
+

--- a/data-raw/R/plot_stock_areas.R
+++ b/data-raw/R/plot_stock_areas.R
@@ -1,0 +1,47 @@
+#' plot stock areas
+#'
+#'
+#'
+#'
+
+plot_stock_areas <- function(coast,statareas,GB,stockArea,keyrunAreas,addAreas=NULL) {
+
+
+  #obj <- mscatch::get_species_object(species_itis = itis,stock = stock)
+  #msk <- mscatch::get_species_object_mskeyrun(species_itis = itis)
+  
+  keyrunAreasSp <- statareas %>% 
+    dplyr::filter(Id %in% keyrunAreas)
+  
+  areas <- statareas %>% 
+    dplyr::filter(Id %in% stockArea)
+  
+  bb <- sf::st_bbox(areas)
+  xmin <- min(bb$xmin,-76)
+  xmax <- max(bb$xmax,-65)
+  ymin <- min(bb$ymin,35)
+  ymax <- max(bb$ymax,45)
+  
+  p <- ggplot2::ggplot(data=coast) +
+    ggplot2::geom_sf() +
+    ggplot2::geom_sf(data= GB,col="grey",alpha = 0.8) +
+    ggplot2::geom_sf(data= areas,col="black",fill="lightgrey",alpha = 0.5) +
+    ggplot2::geom_sf(data= keyrunAreasSp,col="coral",fill="coral",alpha = 0.25) 
+  
+  if (!is.null(addAreas)) {
+    p <-  p +  
+      ggplot2::geom_sf(data = addAreas,col="black",fill="lightgrey",alpha = 0.2)
+    areas = rbind(areas,addAreas)
+  }
+  
+  p <- p +
+    ggplot2::coord_sf(xlim = c(xmin,xmax), ylim = c(ymin,ymax)) +
+    ggplot2::geom_text(data=areas,ggplot2::aes(x=X,y=Y,label=Id),size=2) +
+    ggplot2::xlab("") +
+    ggplot2::ylab("")
+
+    
+
+  
+  return(p)
+}

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -89,6 +89,8 @@ navbar:
      href: articles/GBLandingsByLength.html
    - text: Length Weight relationships
      href: articles/GBLengthWeight.html
+   - text: Survey Biomass and Abundance
+     href: articles/GBbiomassNumbyLength.html
 
 
 

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -84,7 +84,7 @@ navbar:
    - text: Fleet Definitions
      href: articles/GBFleetDecisions.html
    - text: --------
-   - text: Length Based Data
+   - text: Length & Age Based Data
    - text: Landings by Length
      href: articles/GBLandingsByLength.html
    - text: Length Weight relationships

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -51,3 +51,48 @@ reference:
   - focalSpecies
   - fleets
   
+navbar:
+ components:
+  articles:
+   text: Articles
+   menu:
+   - text: Data Needs
+   - text: Project outline
+     href: articles/DataNeeds.html
+   - text: Dataset Dimensions
+     href: articles/DatasetDimensions.html
+   - text: Keyrun Species, Environment, Data Formats
+     href: articles/SpeciesEnvDat.html
+   - text: Age, Length, Diet
+     href: articles/CompsDat.html
+   - text: --------
+   - text: Georges Bank
+   - text: GB Survey Footprint
+     href: articles/GBSurveySet.html
+   - text: Allocate Landings to GB
+     href: articles/allocateLandingsEPU.html
+   - text: Stock areas
+     href: articles/stockAreas.html
+   - text: --------
+   - text: Simulated Data
+   - text: Generating Simulated Data
+     href: articles/SimData.html
+   - text: --------
+   - text: Assigning Fleets
+   - text: Analysis of catch by gear
+     href: articles/GBFleetDefinitions.html
+   - text: Fleet Definitions
+     href: articles/GBFleetDecisions.html
+   - text: --------
+   - text: Length Based Data
+   - text: Landings by Length
+     href: articles/GBLandingsByLength.html
+   - text: Length Weight relationships
+     href: articles/GBLengthWeight.html
+
+
+
+
+
+  
+  

--- a/vignettes/GBFleetDecisions.Rmd
+++ b/vignettes/GBFleetDecisions.Rmd
@@ -1,7 +1,5 @@
 ---
-title: "Fleet Decisions for Georges Bank"
-author: Andy Beet
-date: "`r format(Sys.time(), '%d %B, %Y')`"
+title: "Fleet Definitions for Georges Bank"
 output:
   bookdown::html_document2:
     code_fold: hide
@@ -163,4 +161,12 @@ Predominantly Silver Hake, White Hake, Butterfish, Short fin, and long fin squid
 
 <sup>1,2</sup> 7 - HAUL SEINE (perch, alewife, cod, winter flounder, lobster)
 
+## Data
 
+The resulting data set is in the data package as `fleets`. Since the current length based model, Hydra, includes three fleets, the fleet designations are reduced further to map to the requirements of the Hydra model.
+
+```{r hydrafleet, echo=T, eval=T}
+mskeyrun::fleets %>%
+  flextable::flextable()
+
+```

--- a/vignettes/GBFleetDefinitions.Rmd
+++ b/vignettes/GBFleetDefinitions.Rmd
@@ -1,7 +1,5 @@
 ---
-title: "Fleet Definitions for Georges Bank"
-author: Andy Beet
-date: "`r format(Sys.time(), '%d %B, %Y')`"
+title: "Analysis of Georges Bank catch by gear type"
 output:
   bookdown::html_document2:
     code_fold: hide

--- a/vignettes/GBFleetDefinitions.Rmd
+++ b/vignettes/GBFleetDefinitions.Rmd
@@ -84,17 +84,17 @@ A dendrogram is then formed using the agglomerative hierarchical process. This p
 
 For each gear type the landings of each species are aggregated over time and then ordered from the most abundant to least abundant. To reduce the number of variables (species) in the analysis we only use species which comprise 90% of the total landings for each gear type.
 
-(Figure \@ref(fig:dendro1)) shows the result of this approach. Initial inspection indicates further "cleaning" of the data is required. 
-
 ```{r cluster1, echo=T,eval=F}
 clusterObj <- cluster_analysis_all_gears()
 plot(clusterObj,ask=T,which.plots=2,main="Complete gear list using 90% landing from each gear",xlab="")
 
 ```
 
-```{r dendro1,out.width="100%",fig.cap="The dendrogram obtained from a nearest-neighbor, hierarchical cluster analysis on all gear types used in the Georges Bank Ecological Production unit as defined by statistical areas",eval=T,echo=F}
+```{r dendro1, out.width="100%",fig.cap="The dendrogram obtained from a nearest-neighbor, hierarchical cluster analysis on all gear types used in the Georges Bank Ecological Production unit as defined by statistical areas",eval=T,echo=F}
 knitr::include_graphics("figures/dendrogram1.png")
 ```
+
+
 Note: Low values of the agglomerative coefficient indicate tight clustering of gears types. Larger values indicate less well formed clusters.
 
 
@@ -110,7 +110,7 @@ plot(clusterObj$top,ask=T,which.plots=2,main="Gear types contributing to 99% of 
 ```
 
 
-```{r dendro2,out.width="100%",fig.cap="The dendrogram obtained from a nearest-neighbor, hierarchical cluster analysis on a subset of gear types in the Georges Bank Ecological Production unit as defined by statistical areas. Gear types were selected based on their contribution to 99% of landings",eval=T,echo=F}
+```{r dendro2, out.width="100%",fig.cap="The dendrogram obtained from a nearest-neighbor, hierarchical cluster analysis on a subset of gear types in the Georges Bank Ecological Production unit as defined by statistical areas. Gear types were selected based on their contribution to 99% of landings",eval=T,echo=F}
 knitr::include_graphics("figures/dendrogram2.png")
 
 ```

--- a/vignettes/GBLandingsByAge.Rmd
+++ b/vignettes/GBLandingsByAge.Rmd
@@ -1,0 +1,44 @@
+---
+title: "Landings by Age"
+output:
+  bookdown::html_document2:
+    code_fold: hide
+    number_sections: false
+csl: apa-annotated-bibliography.csl
+bibliography: references.bib
+link-citations: yes
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+library(magrittr)
+library(mskeyrun)
+options(warn=-1)
+```
+
+
+Any Statistical catch at age model will require input data in the form of numbers of fish over a range of ages. This data is obtained in a three step process:
+
+*   The catch is first [expanded](https://noaa-edab.github.io/ms-keyrun/articles/GBLandingsByLength.rmd) to a composition of lengths
+
+*   An [age length key](https://noaa-edab.github.io/ms-keyrun/articles/GBLandingsByLength.html#additional-preferences) is estimated using the expanding catch and age-length data. The method follows that of @gerritsen_simple_2006. The source of the [age-length data](https://noaa-edab.github.io/ms-keyrun/articles/GBLandingsByLength.html#additional-preferences) is often up to the discretion of the assessment scientist and is species dependent. 
+
+*   The numbers of fish at age is then calculated using the age-length key, the expanded catch and the length-weight relationship. This is explained in [`mscatch`])(https://noaa-edab.github.io/mscatch/articles/ageExpansion.html) 
+
+For the mskeyrun project the final data product is aggregated (over quarter or semester) to annual numbers. This data set is exported in the package as [realFisheryAgecomp](https://noaa-edab.github.io/ms-keyrun/reference/realFisheryAgecomp.html). A sample of the output for Atlantic cod is shown below.
+
+
+
+```{r agecomp,echo=F,eval=TRUE}
+mskeyrun::realFisheryAgecomp %>%
+  dplyr::filter(Code == 164499,
+                year == 2000) %>%
+  dplyr::arrange(fishery,age) %>%
+  head(.,10) %>%
+  flextable::flextable() %>% 
+  flextable::colformat_num(j=c("Code","year"), big.mark = "" , digits=0 )
+```
+
+
+## References
+

--- a/vignettes/GBLandingsByLength.Rmd
+++ b/vignettes/GBLandingsByLength.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Landings by Length for Georges Bank"
+title: "Landings by Length"
 output:
   bookdown::html_document2:
     code_fold: hide
@@ -13,6 +13,7 @@ link-citations: yes
 knitr::opts_chunk$set(echo = TRUE)
 library(magrittr)
 library(mskeyrun)
+source(here::here("data-raw/R/create_species_rules_table.r"))
 options(warn=-1)
 ```
 
@@ -22,19 +23,22 @@ For many stock assessment models and multispecies models the catch is often requ
 
 ## Expanding catch to a composition of lengths
 
-For each of the [focal species](stockAreas.html#focal) the annual catch (measured in metric tons) is expanded to a composition of length. The result being that the sum of the catch over all lengths in a given year (or any other time interval) will equal the total catch for that year (or equivalent time interval). Fish are measured in 1 cm increments.
+Hydra, the multispecies length based model, is the only model that requires this type of data. Currently Hydra incorporates three distinct fleets, a demersal fleet, a pelagic fleet, and a fixed gear fleet. This data product categorizes catch by these three fleet types.
 
+The annual catch (measured in metric tons) for each of the [focal species](stockAreas.html#focal) is expanded to a composition of length. The result being that the sum of the catch over all lengths in a given year (or any other time interval) will equal the total catch for that year (or equivalent time interval). Fish are measured in 1 cm increments.
 
 * Commercial fisheries landings were pulled using R package [`comlandr`](https://github.com/NOAA-EDAB/comlandr)
 
-* The length data were pulled from the `stockeff.mv_cf_len` table
+* The length data were pulled from the commercial fisheries database, specifically the `stockeff.mv_cf_len` table
 
-* The R package [`mscatch`](https://noaa-edab.github.io/mscatch/) is used to expand the annual catch data. The methods are explained there. 
+* The R package [`mscatch`](https://noaa-edab.github.io/mscatch/) is used to expand the annual catch data. The methods are explained there. [Species specific rules](#rules) are used this expansion to account for life history traits.
 
 
-For each species, a set of rules are applied (similar to the approach taken in a stock assessment), to determine how the landings and discard data are aggregated based on the availability of length samples. Biomass (metric tons) is then estimated for each LENGTH (1 cm bins) category by YEAR and [fleet](https://noaa-edab.github.io/ms-keyrun/GBFleetDecisions.html). This data set is exported in the package as [`realFisheryLencomp`](https://noaa-edab.github.io/ms-keyrun/reference/realFisheryLencomp.html)
+## Species rules {#rules}
 
-```{r lencomp,echo=T,eval=TRUE}
+For each species, a set of rules are applied (similar to the approach taken in a stock assessment), to determine how the landings data and discard data (not currently incorporated) are aggregated based on the availability of length samples. Biomass (metric tons) is then estimated for each LENGTH (1 cm bins) category for a specified time interval, market category, and gear type. The expanded catch is then aggregated to annual time steps and [fleets](https://noaa-edab.github.io/ms-keyrun/GBFleetDecisions.html). This data set is exported in the package as [`realFisheryLencomp`](https://noaa-edab.github.io/ms-keyrun/reference/realFisheryLencomp.html). A sample of the output for Atlantic cod is shown below.
+
+```{r lencomp,echo=F,eval=TRUE}
 mskeyrun::realFisheryLencomp %>%
   dplyr::filter(Code == 164712) %>%
   head(.,10) %>%
@@ -43,7 +47,38 @@ mskeyrun::realFisheryLencomp %>%
 ```
 
 
+### Fleet/Gear Types
 
+NEGEAR2 codes observed in the catch data are attributed to one of three fleets. The designation "all" implies all other gear codes. Note that some species are not caught by all three fleets.
 
-## References
+```{r speciesgear, echo = F, eval=T}
+tab <- create_species_rules_table1("gearCodes","Fleet","Negear2")
+tab
 
+```
+### Market Codes
+
+In a similar fashion to fleets, the market codes obseved in the catch data are relabelled according to assessment scientist recommendations. The designation "all" implies all other market codes
+
+```{r speciesmarket, echo = F, eval=T}
+tab <- create_species_rules_table1("marketCodes","Relablled","Market Codes")
+tab
+
+```
+### Additional preferences
+
+Additional decision points were considered for each species in accordance with stock scientist recommendations. The following table outlines these decision points:
+
+*   `temporalAggregation` = The time scale that catch is expanded to lengths. Quarterly, by semester or annual time scales.
+*   `howAggregate` = The method for treating catch (at above time scales) that have missing associated length samples. *Note: not all stock scientists borrow length samples from other sampled times. This will be addressed at a later date*
+*   `LengthWeightData` = The data source for obtaining length and weight data. This data is used to fit length-weight relationships at the level defined by `LengthWeightRelationship`.
+*   `LengthWeightRelationship` = The time scale used to fit length-weight relationships. *Note: some stock scientists fit length-weight relationships for each semester in each year. Some fit over a specified time range of survey data. These modifications will be addressed at a later date.*
+*   `AgeData` = The data source for obtaining age data. Note that some species do not have age data available and subsequently age based stock assessments are not carried out.
+*   `AgeLengthKey` = The time scale used to calculate the Age length key. **Note: some stock scientists use year and quarter, some also incorporate gear type. These modifications will be addressed at a later date. **
+*   `maxAge` = The approximate observed maximum age of the species. This is used in the construction of the age length key.
+
+```{r speciesprefs, echo = F, eval=T}
+tab <- create_species_rules_table2()
+tab
+
+```

--- a/vignettes/GBLandingsByLength.Rmd
+++ b/vignettes/GBLandingsByLength.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "Landings by Length for Georges Bank"
-author: Andy Beet
-date: "`r format(Sys.time(), '%d %B, %Y')`"
 output:
   bookdown::html_document2:
     code_fold: hide
@@ -18,77 +16,31 @@ library(mskeyrun)
 options(warn=-1)
 ```
 
-## Goal
+Landings of fish are not recorded by length. Samples of the landed fish are taken through time by port samplers at the request of the assessment scientist. The size of the samples (the number of fish sampled) and the frequency of the samples change through time for several reasons. As a result some species are more heavily sampled than others. In addition some species are more heavily sampled during certain times of the year. In many cases the lengthed fish are assigned a market category, for example, Large, Small, Jumbo. Other times they are not and are simple considered Unclassified
 
-The ultimate goal is to create a data set that contains total annual biomass divided into size classes based on length for each of the [focal species](https://noaa-edab.github.io/ms-keyrun/reference/focalSpecies.html) and for each fleet that targets them. The resulting table will have a format similar to:
+For many stock assessment models and multispecies models the catch is often required as a composition of lengths. Due to the nature of the sampling program, length samples are not always available at the level the model requires. In this case there are several options. One of them being to "borrow" length samples from adjacent time periods. This assumes that fish caught from one time period to the next have similar size (length) distributions.
 
-```{r tabformat, echo=F,eval=T}
+## Expanding catch to a composition of lengths
 
-df <- data.frame(Fleet = c(1,1,1,1,1,1),
-           Area=c(1,1,1,1,1,1),
-           Year =c(1964,1965,1966,1964,1965,1966),
-           Species=c(1,1,1,2,2,2),
-           Biomass=c(222,345,343,2137,678,346),
-           sizeclass1 = c(0,0,0,0,0,0),
-           sizeclass2 = c(0.05,0.05,0.05,0.05,0.05,0.05),
-           sizeclass3 = c(0.25,0.25,0.25,0.25,.25,.25),
-           sizeclass4 = c(0.5,0.5,0.5,0.5,.5,.5),
-           sizeclass5 = c(.25,.25,.25,.25,.25,.25))
+For each of the [focal species](stockAreas.html#focal) the annual catch (measured in metric tons) is expanded to a composition of length. The result being that the sum of the catch over all lengths in a given year (or any other time interval) will equal the total catch for that year (or equivalent time interval). Fish are measured in 1 cm increments.
 
- df %>%  kableExtra::kbl() %>%
-  kableExtra::kable_styling("hover", full_width = F)
 
+* Commercial fisheries landings were pulled using R package [`comlandr`](https://github.com/NOAA-EDAB/comlandr)
+
+* The length data were pulled from the `stockeff.mv_cf_len` table
+
+* The R package [`mscatch`](https://noaa-edab.github.io/mscatch/) is used to expand the annual catch data. The methods are explained there. 
+
+
+For each species, a set of rules are applied (similar to the approach taken in a stock assessment), to determine how the landings and discard data are aggregated based on the availability of length samples. Biomass (metric tons) is then estimated for each LENGTH (1 cm bins) category by YEAR and [fleet](https://noaa-edab.github.io/ms-keyrun/GBFleetDecisions.html). This data set is exported in the package as [`realFisheryLencomp`](https://noaa-edab.github.io/ms-keyrun/reference/realFisheryLencomp.html)
+
+```{r lencomp,echo=T,eval=TRUE}
+mskeyrun::realFisheryLencomp %>%
+  dplyr::filter(Code == 164712) %>%
+  head(.,10) %>%
+  flextable::flextable() %>% 
+  flextable::colformat_num(j=c("Code","year"), big.mark = "" , digits=0 )
 ```
-
-Columns with the format `sizeclassx` represent the xth size class. A size class is defined by a range of lengths (cm) and its width is dependent on the species. Size classes were based on life history traits. For the focal species, the widths of each size class are defined in the following table (subject to change):
-
-```{r hydrabins, echo=F,eval=T,width = "50%", }
-specnames <- c("SPINY DOGFISH","WINTER SKATE","ATLANTIC HERRING", "ATLANTIC COD","HADDOCK","YELLOWTAIL FLOUNDER","WINTER FLOUNDER","ATLANTIC MACKEREL", "SILVER HAKE","GOOSEFISH") 
-
-tab <- hydradata::hydraDataList$binwidth %>% 
-  dplyr::mutate(COMMON_NAME =  specnames )
-itis <- mscatch::speciesLookupTable %>%
-  dplyr::rename(COMMON_NAME = COMMON_NAME.y) %>%
-  dplyr::filter(COMMON_NAME %in% unique(tab$COMMON_NAME)) %>%
-  dplyr::select(COMMON_NAME,SPECIES_ITIS) %>% 
-  dplyr::rename(species_itis = SPECIES_ITIS) %>%
-  dplyr::distinct()
-
-tab <- tab %>% 
-  dplyr::left_join(.,itis,by=c("COMMON_NAME")) %>% 
-  dplyr::select(-COMMON_NAME)
-row.names(tab) <- specnames
-
-
-tab %>%  kableExtra::kbl() %>%
-  kableExtra::kable_styling("hover", full_width = F)
-
-```
-
-For example, the first size class for SPINY DOGFISH is [0-20] cm, the second class is (20-40] cm, ..., the 5 size class is (80-110] cm.
-
-## Data and methods
-
-Commercial fisheries landings were pulled using R package [`comlandr`](https://github.com/NOAA-EDAB/comlandr)
-
-The length data were pulled from the `stockeff.mv_cf_len` table
-
-The package [`mscatch`](https://noaa-edab.github.io/mscatch/) is used to facilitate these data pulls.
-
-For each species, a set of rules are applied (similar to the approach taken in a stock assessment), to determine how the landings and discard data are aggregated based on the availability of length samples. Biomass is then estimated for each LENGTH (1 cm bins) category by YEAR and \link{https://noaa-edab.github.io/ms-keyrun/GBFleetDecisions.html}{fleet}. This data set is exported in the package as [`realFisheryLencomp`](https://noaa-edab.github.io/ms-keyrun/reference/realFisheryLencomp.html)
-
-Detailed methods can be found in the [`mscatch`](https://noaa-edab.github.io/mscatch/) package
-
-
-## Hydra fleets
-
-The [fleet](https://noaa-edab.github.io/ms-keyrun/GBFleetDecisions.html) definitions for the Hydra model are defined in the table:
-
-```{r hydrafleet, echo=T, eval=T}
-mskeyrun::fleets %>%  kableExtra::kbl() %>%
-  kableExtra::kable_styling("hover", full_width = F)
-```
-
 
 
 

--- a/vignettes/GBLandingsByLength.Rmd
+++ b/vignettes/GBLandingsByLength.Rmd
@@ -17,7 +17,7 @@ source(here::here("data-raw/R/create_species_rules_table.r"))
 options(warn=-1)
 ```
 
-Landings of fish are not recorded by length. Samples of the landed fish are taken through time by port samplers at the request of the assessment scientist. The size of the samples (the number of fish sampled) and the frequency of the samples change through time for several reasons. As a result some species are more heavily sampled than others. In addition some species are more heavily sampled during certain times of the year. In many cases the lengthed fish are assigned a market category, for example, Large, Small, Jumbo. Other times they are not and are simple considered Unclassified
+Typically, fish that are landed by fishermen are not measured for length. However samples of the landed fish are taken through time by port samplers at the request of the assessment scientist. The size of the samples (the number of fish sampled) and the frequency of the samples change through time for several reasons. As a result some species are more heavily sampled than others. In addition some species are more heavily sampled during certain times of the year. In many cases the lengthed fish are assigned a market category, for example, Large, Small, Jumbo. Other times they are not and are simple considered Unclassified
 
 For many stock assessment models and multispecies models the catch is often required as a composition of lengths. Due to the nature of the sampling program, length samples are not always available at the level the model requires. In this case there are several options. One of them being to "borrow" length samples from adjacent time periods. This assumes that fish caught from one time period to the next have similar size (length) distributions.
 
@@ -27,16 +27,16 @@ Hydra, the multispecies length based model, is the only model that requires this
 
 The annual catch (measured in metric tons) for each of the [focal species](stockAreas.html#focal) is expanded to a composition of length. The result being that the sum of the catch over all lengths in a given year (or any other time interval) will equal the total catch for that year (or equivalent time interval). Fish are measured in 1 cm increments.
 
-* Commercial fisheries landings were pulled using R package [`comlandr`](https://github.com/NOAA-EDAB/comlandr)
+* Commercial fisheries landings were pulled using R package [`comlandr`](https://noaa-edab.github.io/comlandr/)
 
 * The length data were pulled from the commercial fisheries database, specifically the `stockeff.mv_cf_len` table
 
-* The R package [`mscatch`](https://noaa-edab.github.io/mscatch/) is used to expand the annual catch data. The methods are explained there. [Species specific rules](#rules) are used this expansion to account for life history traits.
+* The R package [`mscatch`](https://noaa-edab.github.io/mscatch/) is used to expand the annual catch data. The methods are explained there. [Species specific rules](#rules) are used in the expansion to account for life history traits.
 
 
 ## Species rules {#rules}
 
-For each species, a set of rules are applied (similar to the approach taken in a stock assessment), to determine how the landings data and discard data (not currently incorporated) are aggregated based on the availability of length samples. Biomass (metric tons) is then estimated for each LENGTH (1 cm bins) category for a specified time interval, market category, and gear type. The expanded catch is then aggregated to annual time steps and [fleets](https://noaa-edab.github.io/ms-keyrun/GBFleetDecisions.html). This data set is exported in the package as [`realFisheryLencomp`](https://noaa-edab.github.io/ms-keyrun/reference/realFisheryLencomp.html). A sample of the output for Atlantic cod is shown below.
+For each species, a set of rules are applied (similar to the approach taken in a stock assessment), to determine how the landings data and discard data (not currently incorporated) are aggregated based on the availability of length samples. Biomass (metric tons) is then estimated for each LENGTH (1 cm bins) category for a specified time interval, market category, and gear type. The expanded catch is then aggregated to annual time steps and [fleets](https://noaa-edab.github.io/ms-keyrun/articles/GBFleetDecisions.html). This data set is exported in the package as [`realFisheryLencomp`](https://noaa-edab.github.io/ms-keyrun/reference/realFisheryLencomp.html). A sample of the output for Atlantic cod is shown below.
 
 ```{r lencomp,echo=F,eval=TRUE}
 mskeyrun::realFisheryLencomp %>%
@@ -58,7 +58,7 @@ tab
 ```
 ### Market Codes
 
-In a similar fashion to fleets, the market codes obseved in the catch data are relabelled according to assessment scientist recommendations. The designation "all" implies all other market codes
+In a similar fashion to fleets, the market codes observed in the catch data are relabelled according to assessment scientist recommendations. The designation "all" implies all other market codes
 
 ```{r speciesmarket, echo = F, eval=T}
 tab <- create_species_rules_table1("marketCodes","Relablled","Market Codes")
@@ -70,11 +70,11 @@ tab
 Additional decision points were considered for each species in accordance with stock scientist recommendations. The following table outlines these decision points:
 
 *   `temporalAggregation` = The time scale that catch is expanded to lengths. Quarterly, by semester or annual time scales.
-*   `howAggregate` = The method for treating catch (at above time scales) that have missing associated length samples. *Note: not all stock scientists borrow length samples from other sampled times. This will be addressed at a later date*
+*   `howAggregate` = The method for dealing with missing length samples (at above time scales). *Note: not all stock scientists borrow length samples from other sampled times. This will be addressed at a later date*
 *   `LengthWeightData` = The data source for obtaining length and weight data. This data is used to fit length-weight relationships at the level defined by `LengthWeightRelationship`.
 *   `LengthWeightRelationship` = The time scale used to fit length-weight relationships. *Note: some stock scientists fit length-weight relationships for each semester in each year. Some fit over a specified time range of survey data. These modifications will be addressed at a later date.*
 *   `AgeData` = The data source for obtaining age data. Note that some species do not have age data available and subsequently age based stock assessments are not carried out.
-*   `AgeLengthKey` = The time scale used to calculate the Age length key. **Note: some stock scientists use year and quarter, some also incorporate gear type. These modifications will be addressed at a later date. **
+*   `AgeLengthKey` = The time scale used to calculate the Age length key. *Note: some stock scientists use year and quarter, some also incorporate gear type. These modifications will be addressed at a later date. *
 *   `maxAge` = The approximate observed maximum age of the species. This is used in the construction of the age length key.
 
 ```{r speciesprefs, echo = F, eval=T}

--- a/vignettes/GBbiomassNumbyLength.rmd
+++ b/vignettes/GBbiomassNumbyLength.rmd
@@ -29,7 +29,6 @@ The R package [`survdat`](https://noaa-edab.github.io/survdat/) is used to read 
 source(here::here("data-raw/R/create_real_survey_lennumcomp.r"))
 suppressMessages(out <- create_real_survey_lennumcomp(convertKGtoMT=T))
 
-
 ```
 
 ## Spring Biomass: length-frequency plots {.tabset}

--- a/vignettes/REFERENCES.bib
+++ b/vignettes/REFERENCES.bib
@@ -33,4 +33,22 @@
     url = {https://CRAN.R-project.org/package=cluster},
     note = {R package version 2.1.1 --- For new features, see the
       'Changelog' file (in the package source)},
-  }
+}
+
+@article{gerritsen_simple_2006,
+	title = {A simple method for comparing age–length keys reveals significant regional differences within a single stock of haddock ({Melanogrammus} aeglefinus)},
+	volume = {63},
+	issn = {1054-3139},
+	url = {https://doi.org/10.1016/j.icesjms.2006.04.008},
+	doi = {10.1016/j.icesjms.2006.04.008},
+	abstract = {A multinomial logistic model is presented as a tool for comparing two or more age–length keys. The model provides an objective way to fill in missing values and can be used for estimating uncertainty and visualizing age–length keys (ALKs). An example of haddock (Melanogrammus aeglefinus) in ICES Division VIa (West of Scotland) is used to illustrate significant regional differences in the proportions of age-at-length. These differences are caused by regional variation in both length-at-age and relative abundance at age. As the length-at-age data are normally not weighted by the local catch rate (abundance), the ALK of the combined age data can result in strongly biased estimates of numbers-at-age. In the present case, the use of unweighted age data would have resulted in an overestimate of recruitment of nearly 200\%, and an underestimate of spawning-stock biomass of 15\%. Comparing ALKs using this method has several practical applications.},
+	number = {6},
+	urldate = {2021-02-02},
+	journal = {ICES Journal of Marine Science},
+	author = {Gerritsen, Hans D. and McGrath, David and Lordan, Colm},
+	month = jan,
+	year = {2006},
+	pages = {1096--1100},
+	file = {Gerritsen et al. - 2006 - A simple method for comparing age–length keys reve.pdf:C\:\\Users\\andrew.beet\\Zotero\\storage\\3EELL9N7\\Gerritsen et al. - 2006 - A simple method for comparing age–length keys reve.pdf:application/pdf;Snapshot:C\:\\Users\\andrew.beet\\Zotero\\storage\\UEYTWNVR\\616149.html:text/html},
+}
+

--- a/vignettes/stockAreas.Rmd
+++ b/vignettes/stockAreas.Rmd
@@ -63,7 +63,7 @@ species <- data.frame(itis = c("172909","172414","161722","164744","172905","172
 ```{r acod, echo = F}
 itis <- 164712
 speciesRules <- mscatch::get_species_object(itis,stock = NA)
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
 print(p)
   
@@ -73,7 +73,7 @@ print(p)
 ```{r aherring, echo = F }
 itis <- 161722
 speciesRules <- mscatch::get_species_object(itis,stock = NA)
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
 print(p)
 ```
@@ -82,7 +82,7 @@ print(p)
 ```{r amackerel, echo = F}
 itis <- 172414
 speciesRules <- mscatch::get_species_object(itis,stock = NA)
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
 print(p)
 ```
@@ -91,7 +91,7 @@ print(p)
 ```{r hadd, echo = F}
 itis <- 164744
 speciesRules <- mscatch::get_species_object(itis,stock = NA)
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
 print(p)
 ```
@@ -100,7 +100,7 @@ print(p)
 ```{r goose, echo = F}
 itis <- 164499
 speciesRules <- mscatch::get_species_object(itis,stock = NA)
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
 print(p)
 ```
@@ -113,7 +113,7 @@ Winter Flounder comprises two stocks; a Georges Bank stock (Eastern portion of G
 ```{r winfl, echo = F}
 itis <- 172905
 speciesRules <- mscatch::get_species_object(itis,stock = "GB")
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 
 speciesRulesSNEMA <- mscatch::get_species_object(itis,stock = "SNEMA")
 areasSNEMA <- statareas %>%
@@ -128,7 +128,7 @@ print(p)
 ```{r ytfl, echo = F}
 itis <- 172909
 speciesRules <- mscatch::get_species_object(itis,stock = NA)
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
 print(p)
 ```
@@ -140,7 +140,7 @@ Silver Hake comprises two stocks; a northern and southern stock. The boundary be
 ```{r silhake, echo = F}
 itis <- 164791
 speciesRules <- mscatch::get_species_object(itis,stock = "North")
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 
 # Additional stock area
 speciesRulesS <- mscatch::get_species_object(itis,stock = "South")
@@ -157,7 +157,7 @@ print(p)
 ```{r spindog, echo = F}
 itis <- 160617
 speciesRules <- mscatch::get_species_object(itis,stock = NA)
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
 print(p)
 ```
@@ -166,7 +166,7 @@ print(p)
 ```{r winskate, echo = F}
 itis <- 564145
 speciesRules <- mscatch::get_species_object(itis,stock = NA)
-speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis)
 p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
 print(p)
 

--- a/vignettes/stockAreas.Rmd
+++ b/vignettes/stockAreas.Rmd
@@ -1,6 +1,8 @@
 ---
 title: "Focal Species stock area definitions"
-output: github_document
+output:
+  html_document:
+    code_fold: hide
 ---
 
 ```{r setup, include=FALSE}
@@ -15,7 +17,7 @@ source(here::here("data-raw/R/plot_stock_areas.R"))
 
 ## Focal species
 
-```{r focalSpTab, echo = F, eval=T}
+```{r , echo = F, eval=T}
 focalSpecies %>%
   dplyr::select(LongName,SCIENTIFIC_NAME,SPECIES_ITIS) %>%
   dplyr::filter(!(LongName == "Pollock")) %>%
@@ -24,15 +26,15 @@ focalSpecies %>%
   dplyr::distinct() %>%
   flextable::flextable() %>%
   flextable::autofit()
-
 ```
 
 
 
 ##  Stock areas 
 
-Numbered Statistical areas define the stock area used in an assessment. Overlayed in red denotes the statistical areas used to 
-pull catch data for the Georges Bank region.
+Numbered Statistical areas define the stock area used in an assessment. Overlaid in red denotes the statistical areas used to pull catch data for the Georges Bank region.
+
+Length sample data are also pulled from the GB region. For stocks that are transient on Georges Bank (Herring, Mackerel, Spiny dogfish, Winter skate, Goosefish) length samples are used from the whole shelf.
 
 
 ```{r stocks, echo = F, eval = T}
@@ -139,19 +141,14 @@ Silver Hake comprises two stocks; a northern and southern stock. The boundary be
 itis <- 164791
 speciesRules <- mscatch::get_species_object(itis,stock = "North")
 speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
-p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+
 # Additional stock area
 speciesRulesS <- mscatch::get_species_object(itis,stock = "South")
-
-areasN <- statareas %>% 
-    dplyr::filter(Id %in% speciesRules$statStockArea)
 areasS <- statareas %>% 
     dplyr::filter(Id %in% speciesRulesS$statStockArea)
-p <- p +
-  ggplot2::geom_sf(data= areasN,col="black",fill="lightgrey",alpha = 0.5) +
-  ggplot2::geom_sf(data= areasS,col="black",fill="lightgrey",alpha = 0.2) + 
-  ggplot2::geom_text(data=areasS,ggplot2::aes(x=X,y=Y,label=Id),size=2)
-  
+
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea,addAreas = areasS)
+
 
 print(p)
 ```

--- a/vignettes/stockAreas.Rmd
+++ b/vignettes/stockAreas.Rmd
@@ -15,7 +15,7 @@ source(here::here("data-raw/R/plot_stock_areas.R"))
 ```
 
 
-## Focal species
+## Focal species {#focal}
 
 ```{r , echo = F, eval=T}
 focalSpecies %>%

--- a/vignettes/stockAreas.Rmd
+++ b/vignettes/stockAreas.Rmd
@@ -8,15 +8,15 @@ knitr::opts_chunk$set(echo = TRUE)
 library(magrittr)
 library(mskeyrun)
 source(here::here("data-raw/R/capitalize_first_letter.R"))
+source(here::here("data-raw/R/plot_stock_areas.R"))
 
 ```
 
 
 ## Focal species
 
-```{r focalSpTable, echo = F, eval =T}
-
-mskeyrun::focalSpecies %>%
+```{r focalSpTab, echo = F, eval=T}
+focalSpecies %>%
   dplyr::select(LongName,SCIENTIFIC_NAME,SPECIES_ITIS) %>%
   dplyr::filter(!(LongName == "Pollock")) %>%
   dplyr::rename(Common_Name = LongName) %>%
@@ -36,6 +36,7 @@ pull catch data for the Georges Bank region.
 
 
 ```{r stocks, echo = F, eval = T}
+
 options(warn = -1)
 crs <- 4326
 coast <- sf::st_read(here::here("data-raw/gis/NES_LME_coast.shp"), quiet = T) %>%
@@ -43,7 +44,8 @@ coast <- sf::st_read(here::here("data-raw/gis/NES_LME_coast.shp"), quiet = T) %>
 
 suppressMessages(sf::sf_use_s2(FALSE))
 
-statareas <- NEFSCspatial::Statistical_Areas_2010
+statareas <- NEFSCspatial::Statistical_Areas_2010  %>%
+  sf::st_transform(.,crs=crs)
 centroids <- sf::st_coordinates(sf::st_centroid(statareas))
 statareas <- cbind(statareas,centroids)
 
@@ -57,41 +59,120 @@ species <- data.frame(itis = c("172909","172414","161722","164744","172905","172
 ### Atlantic cod
 
 ```{r acod, echo = F}
-
+itis <- 164712
+speciesRules <- mscatch::get_species_object(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+print(p)
+  
 ```
 
 ### Atlantic Herring
 ```{r aherring, echo = F }
+itis <- 161722
+speciesRules <- mscatch::get_species_object(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+print(p)
 ```
 
 ### Atlantic Mackerel
-```{r, echo = F}
+```{r amackerel, echo = F}
+itis <- 172414
+speciesRules <- mscatch::get_species_object(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+print(p)
 ```
 
 ### Haddock
-```{r, echo = F}
+```{r hadd, echo = F}
+itis <- 164744
+speciesRules <- mscatch::get_species_object(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+print(p)
 ```
 
 ### Goosefish
-```{r, echo = F}
+```{r goose, echo = F}
+itis <- 164499
+speciesRules <- mscatch::get_species_object(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+print(p)
 ```
 
 ### Winter flounder
-```{r, echo = F}
+
+
+Winter Flounder comprises two stocks; a Georges Bank stock (Eastern portion of Georges Bank) and a Southen New England stock. The boundary between the two lies through the center of Georges Bank (longitudanally)
+
+```{r winfl, echo = F}
+itis <- 172905
+speciesRules <- mscatch::get_species_object(itis,stock = "GB")
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+
+speciesRulesSNEMA <- mscatch::get_species_object(itis,stock = "SNEMA")
+areasSNEMA <- statareas %>%
+  dplyr::filter(Id %in% speciesRulesSNEMA$statStockArea)
+
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea,
+                      addAreas = areasSNEMA)
+print(p)
 ```
 
 ### Yellowtail flounder
-```{r, echo = F}
+```{r ytfl, echo = F}
+itis <- 172909
+speciesRules <- mscatch::get_species_object(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+print(p)
 ```
 
 ### Silver hake
-```{r, echo = F}
+
+Silver Hake comprises two stocks; a northern and southern stock. The boundary between the two lies through the center of Georges Bank (latitudinally)
+
+```{r silhake, echo = F}
+itis <- 164791
+speciesRules <- mscatch::get_species_object(itis,stock = "North")
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+# Additional stock area
+speciesRulesS <- mscatch::get_species_object(itis,stock = "South")
+
+areasN <- statareas %>% 
+    dplyr::filter(Id %in% speciesRules$statStockArea)
+areasS <- statareas %>% 
+    dplyr::filter(Id %in% speciesRulesS$statStockArea)
+p <- p +
+  ggplot2::geom_sf(data= areasN,col="black",fill="lightgrey",alpha = 0.5) +
+  ggplot2::geom_sf(data= areasS,col="black",fill="lightgrey",alpha = 0.2) + 
+  ggplot2::geom_text(data=areasS,ggplot2::aes(x=X,y=Y,label=Id),size=2)
+  
+
+print(p)
 ```
 
 ### Spiny dogfish
-```{r, echo = F}
+```{r spindog, echo = F}
+itis <- 160617
+speciesRules <- mscatch::get_species_object(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+print(p)
 ```
 
 ### Winter skate
-```{r, echo = F}
+```{r winskate, echo = F}
+itis <- 564145
+speciesRules <- mscatch::get_species_object(itis,stock = NA)
+speciesKeyrun <- mscatch::get_species_object_mskeyrun(itis,stock = NA)
+p <- plot_stock_areas(coast,statareas,GB,speciesRules$statStockArea,speciesKeyrun$statStockArea)
+print(p)
+
+options(warn = 0)
+
 ```


### PR DESCRIPTION
## Documentation

* Added `stockareas.rmd`. Shows stock areas of each of the focal species with GB overlaid
* Added section in pkgdown.yml to organize articles
* Reworded some text in `GBfleetdecisions`,`GBfleetdefinitions` vignetes