### PR TITLE
Add all simulation data sets to _pkgdown.yml

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -10,32 +10,7 @@ reference:
 - title: "Simulated data products"
   desc: "Extracted from Atlantis output "
 - contents:
-  - simFocalSpecies
-  - simCatchIndex
-  - simCatchIndexSubannual
-  - simCatchIndexFW
-  - simCatchIndexSubannualFW
-  - simFisheryAgecomp
-  - simFisheryAgecompSubannual
-  - simFisheryLencomp
-  - simFisheryLencompSubannual
-  - simFisheryAgeLencomp
-  - simFisheryWtatAge
-  - simFisheryWtatAgeSubannual
-  - simSurveyIndex
-  - simSurveyIndexFW
-  - simSurveyInfo
-  - simSurveyAgecomp
-  - simSurveyLencomp
-  - simSurveyAgeLencomp
-  - simSurveyWtatAge
-  - simSurveyDietcomp
-  - simSurveyLenDietcomp
-  - simSurveyDietcompFW
-  - simSurveyBottemp
-  - simBiolPar
-  - simPerCapCons
-  - simStartPars
+  - starts_with("sim")
 - title: "Survey data products"
   desc: "Extracted from Bottom trawl surveys "
 - contents:


### PR DESCRIPTION
Without this, pkgdown throws an error when trying to update the documentation site.